### PR TITLE
feat(typography): Add `.fonts_html_dependency()` method

### DIFF
--- a/docs/pkg/py/typography.qmd
+++ b/docs/pkg/py/typography.qmd
@@ -224,12 +224,14 @@ link
 
 | Name | Description |
 | --- | --- |
-| [css_include_fonts](#brand_yml.BrandTypography.css_include_fonts) | Generates CSS include statements for the defined fonts. |
+| [fonts_css_include](#brand_yml.BrandTypography.fonts_css_include) | Generates CSS include statements for the defined fonts. |
+| [fonts_html_dependency](#brand_yml.BrandTypography.fonts_html_dependency) | Generate an HTMLDependency for the font CSS and font files. |
+| [fonts_write_css](#brand_yml.BrandTypography.fonts_write_css) | Writes `fonts.css` into a directory, with copies of local fonts. |
 
-### css_include_fonts { #brand_yml.BrandTypography.css_include_fonts }
+### fonts_css_include { #brand_yml.BrandTypography.fonts_css_include }
 
 ```python
-BrandTypography.css_include_fonts()
+BrandTypography.fonts_css_include()
 ```
 
 Generates CSS include statements for the defined fonts.
@@ -242,6 +244,75 @@ defined in the typography configuration.
 | Name   | Type         | Description                                                       |
 |--------|--------------|-------------------------------------------------------------------|
 |        | [str](`str`) | A string containing CSS include statements for all defined fonts. |
+
+### fonts_html_dependency { #brand_yml.BrandTypography.fonts_html_dependency }
+
+```python
+BrandTypography.fonts_html_dependency(
+    path_dir
+    name='brand-fonts'
+    version='0.0.1'
+)
+```
+
+Generate an HTMLDependency for the font CSS and font files.
+
+This method creates an [HTMLDependency
+object](https://shiny.posit.co/py/api/core/Htmltools.html#htmltools.HTMLDependency)
+for the font CSS file and supporting font files written by the
+[`.fonts_html_dependency()`](`brand_yml.BrandTypography.fonts_html_dependency`)
+method. It's useful for integrating the font styles into web or
+[Shiny](https://shiny.posit.co/py) applications that use
+[htmltools](https://pypi.org/project/htmltools/).
+
+#### Parameters {.doc-section .doc-section-parameters}
+
+<code><span class="parameter-name">path_dir</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[str](`str`) \| [Path](`pathlib.Path`)</span></code>
+
+:   The directory path where the CSS file will be written.
+
+<code><span class="parameter-name">name</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[str](`str`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">'brand-fonts'</span></code>
+
+:   The name of the dependency. Defaults to "brand-fonts".
+
+<code><span class="parameter-name">version</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[str](`str`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">'0.0.1'</span></code>
+
+:   The version of the dependency. Defaults to "0.0.1".
+
+#### Returns {.doc-section .doc-section-returns}
+
+| Name   | Type                                                 | Description                                                                                                                                           |
+|--------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+|        | [HTMLDependency](`htmltools.HTMLDependency`) \| None | An [`htmltools.HTMLDependency`](`htmltools.HTMLDependency`) object if `typography` includes font file definitions or `None` if no font CSS is needed. |
+
+### fonts_write_css { #brand_yml.BrandTypography.fonts_write_css }
+
+```python
+BrandTypography.fonts_write_css(path_dir, file_css='fonts.css')
+```
+
+Writes `fonts.css` into a directory, with copies of local fonts.
+
+Writes a `fonts.css` file (or `file_css`) into `path_dir` and copies any
+local fonts into the directory as well.
+
+#### Parameters {.doc-section .doc-section-parameters}
+
+<code><span class="parameter-name">path_dir</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[str](`str`) \| [Path](`pathlib.Path`)</span></code>
+
+:   Path to the directory with the CSS file and copies of the local
+    fonts should be written. If it does not exist it will be created.
+
+<code><span class="parameter-name">file_css</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[str](`str`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">'fonts.css'</span></code>
+
+:   The name of the CSS file with the font `@import` and `@font-face`
+    rules should be written.
+
+#### Returns {.doc-section .doc-section-returns}
+
+| Name   | Type                           | Description                                                                      |
+|--------|--------------------------------|----------------------------------------------------------------------------------|
+|        | [Path](`pathlib.Path`) \| None | Returns the path to the directory where the files were written, i.e. `path_dir`. |
 
 # typography { #brand_yml.typography }
 

--- a/pkg-py/src/brand_yml/typography.py
+++ b/pkg-py/src/brand_yml/typography.py
@@ -30,6 +30,7 @@ from typing import (
 )
 from urllib.parse import urlencode, urljoin
 
+from htmltools import HTMLDependency
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -1432,7 +1433,7 @@ class BrandTypography(BrandBase):
         use_fallback("monospace_block")
         return self
 
-    def css_include_fonts(self) -> str:
+    def fonts_css_include(self) -> str:
         """
         Generates CSS include statements for the defined fonts.
 
@@ -1453,7 +1454,7 @@ class BrandTypography(BrandBase):
 
         return "\n".join([i for i in includes if i])
 
-    def css_write_font_css(
+    def fonts_write_css(
         self,
         path_dir: str | Path,
         file_css: str = "fonts.css",
@@ -1490,11 +1491,10 @@ class BrandTypography(BrandBase):
 
         path_dir.mkdir(parents=True, exist_ok=True)
 
-        # Write fonts.css from typography.css_include_fonts()
         font_css = path_dir / file_css
-        font_css.write_text(self.css_include_fonts())
+        font_css.write_text(self.fonts_css_include())
 
-        # Copy local files from typography.fonts into the temp dir
+        # Copy local files from typography.fonts into the output directory
         for font in self.fonts:
             if isinstance(font, BrandTypographyFontFiles):
                 for file in font.files:
@@ -1504,3 +1504,49 @@ class BrandTypography(BrandBase):
                         shutil.copyfile(file.path.absolute(), dest_path)
 
         return path_dir
+
+    def fonts_html_dependency(
+        self,
+        path_dir: str | Path,
+        name: str = "brand-fonts",
+        version: str = "0.0.1",
+    ) -> HTMLDependency | None:
+        """
+        Generate an HTMLDependency for the font CSS and font files.
+
+        This method creates an [HTMLDependency
+        object](https://shiny.posit.co/py/api/core/Htmltools.html#htmltools.HTMLDependency)
+        for the font CSS file and supporting font files written by the
+        [`.fonts_html_dependency()`](`brand_yml.BrandTypography.fonts_html_dependency`)
+        method. It's useful for integrating the font styles into web or
+        [Shiny](https://shiny.posit.co/py) applications that use
+        [htmltools](https://pypi.org/project/htmltools/).
+
+        Parameters
+        ----------
+        path_dir
+            The directory path where the CSS file will be written.
+        name
+            The name of the dependency. Defaults to "brand-fonts".
+        version
+            The version of the dependency. Defaults to "0.0.1".
+
+        Returns
+        -------
+        :
+            An [`htmltools.HTMLDependency`](`htmltools.HTMLDependency`) object
+            if `typography` includes font file definitions or `None` if no font
+            CSS is needed.
+
+        """
+        subdir = self.fonts_write_css(path_dir, "fonts.css")
+        if subdir is None:
+            return
+
+        return HTMLDependency(
+            name=name,
+            version=version,
+            source={"subdir": str(subdir)},
+            stylesheet={"href": "fonts.css"},
+            all_files=True,
+        )

--- a/pkg-py/tests/test_typography.py
+++ b/pkg-py/tests/test_typography.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from urllib.parse import unquote
 
@@ -742,3 +743,18 @@ def test_brand_typography_undefined_colors():
     assert isinstance(brand.typography, BrandTypography)
     assert isinstance(brand.typography.headings, BrandTypographyHeadings)
     assert brand.typography.headings.color == "orange"
+
+
+def test_brand_typography_write_font_css():
+    brand = Brand.from_yaml(path_examples("brand-typography-fonts.yml"))
+
+    assert isinstance(brand.typography, BrandTypography)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        res = brand.typography.css_write_font_css(tmpdir)
+        assert res is not None
+        assert res == Path(tmpdir).resolve()
+
+        assert (res / "fonts.css").exists()
+        assert (res / "fonts/open-sans/OpenSans-Variable.ttf").exists()
+        assert (res / "fonts/open-sans/OpenSans-Variable-Italic.ttf").exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "ruamel-yaml>=0.18.0",
     "pydantic>=2",
     "eval-type-backport>=0.2.0",
+    "htmltools>=0.2.0"
 ]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
* `.fonts_css_write()` - Adds a method to write a `fonts.css` file into a directory, copying over any local files associated with the brand.
* `.fonts_html_dependency()` - Uses the above method to create an HTMLDependency.

The first method is broadly applicable for any web framework and the second is designed to work with [htmltools](https://github.com/posit-dev/py-htmltools) and [Shiny](https://shiny.posit.co/py). Importantly, the `.fonts_html_dependency()` method leaves the decision about where to store the dependency up to the caller, which will let us build on tempdir management machinery in Shiny that we don't want to repeat in brand_yml.