### PR TITLE
feat(color): Improved `.to_dict()` method

### DIFF
--- a/docs/pkg/py/color.qmd
+++ b/docs/pkg/py/color.qmd
@@ -237,3 +237,30 @@ dark
 
     A dark color, used as a high-contrast foreground color on light elements
     or high-contrast background color on light elements.
+
+## Methods
+
+| Name | Description |
+| --- | --- |
+| [to_dict](#brand_yml.BrandColor.to_dict) | Returns a flat dictionary of color definitions. |
+
+### to_dict { #brand_yml.BrandColor.to_dict }
+
+```python
+BrandColor.to_dict(include='all')
+```
+
+Returns a flat dictionary of color definitions.
+
+#### Parameters {.doc-section .doc-section-parameters}
+
+<code><span class="parameter-name">include</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Literal](`typing.Literal`)\[\'all\', \'theme\', \'palette\'\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">'all'</span></code>
+
+:   Which colors to include: all brand colors (`"all"`), the brand's
+    theme colors (`"theme"`) or the brand's color palette (`"palette"`).
+
+#### Returns {.doc-section .doc-section-returns}
+
+| Name   | Type                                         | Description                                                                                                                                                                                                                                                                                                                                                |
+|--------|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|        | [dict](`dict`)\[[str](`str`), [str](`str`)\] | A flat dictionary of color definitions. Which colors are returned depends on the value of `include`:  * `"all"` returns a flat dictionary of colors with theme colors overlaid   on `color.palette`. * `"theme"` returns a dictionary of only the theme colors, excluding   `color.palette`. * `"palette"` returns a dictionary of only the palette colors |

--- a/pkg-py/src/brand_yml/__init__.py
+++ b/pkg-py/src/brand_yml/__init__.py
@@ -271,7 +271,7 @@ class Brand(BrandBase):
         if self.typography is None:
             return self
 
-        color_defs = self.color._color_defs() if self.color else {}
+        color_defs = self.color.to_dict() if self.color else {}
         color_names = [
             k for k in BrandColor.model_fields.keys() if k != "palette"
         ]

--- a/pkg-py/src/brand_yml/__init__.py
+++ b/pkg-py/src/brand_yml/__init__.py
@@ -271,7 +271,7 @@ class Brand(BrandBase):
         if self.typography is None:
             return self
 
-        color_defs = self.color._color_defs(resolved=True) if self.color else {}
+        color_defs = self.color._color_defs() if self.color else {}
         color_names = [
             k for k in BrandColor.model_fields.keys() if k != "palette"
         ]

--- a/pkg-py/src/brand_yml/color.py
+++ b/pkg-py/src/brand_yml/color.py
@@ -220,7 +220,7 @@ class BrandColor(BrandBase):
 
         return value
 
-    def _color_defs(
+    def to_dict(
         self,
         include: Literal["all", "theme", "palette"] = "all",
     ) -> dict[str, str]:
@@ -260,7 +260,7 @@ class BrandColor(BrandBase):
     def resolve_palette_values(self):
         defs_replace_recursively(
             self,
-            defs=self._color_defs(),
+            defs=self.to_dict(),
             name="color",
             exclude="palette",
         )

--- a/pkg-py/tests/test_color.py
+++ b/pkg-py/tests/test_color.py
@@ -85,7 +85,7 @@ def test_brand_color_ex_palette_internal(snapshot_json):
     assert snapshot_json == pydantic_data_from_json(brand)
 
 
-def test_brand_color_defs():
+def test_brandto_dict():
     brand = Brand.from_yaml_str(
         """
         color:
@@ -94,6 +94,7 @@ def test_brand_color_defs():
             green: "#0f0"
             blue: "#00f"
             azul: blue
+            tertiary: "#f0f"
           primary: red
           secondary: green
           tertiary: blue
@@ -101,13 +102,13 @@ def test_brand_color_defs():
     )
 
     assert isinstance(brand.color, BrandColor)
-    assert brand.color._color_defs(include="theme") == {
+    assert brand.color.to_dict(include="theme") == {
         "primary": "#f00",
         "secondary": "#0f0",
         "tertiary": "#00f",
     }
 
-    assert brand.color._color_defs(include="theme") == {
+    assert brand.color.to_dict(include="theme") == {
         "primary": "#f00",
         "secondary": "#0f0",
         "tertiary": "#00f",
@@ -117,9 +118,20 @@ def test_brand_color_defs():
     # color palette values are resolved on model validation (may change)
     assert brand.color.palette["azul"] == "#00f"
 
-    assert brand.color._color_defs(include="palette") == {
+    assert brand.color.to_dict(include="palette") == {
         "red": "#f00",
         "green": "#0f0",
         "blue": "#00f",
         "azul": "#00f",
+        "tertiary": "#f0f",
+    }
+
+    assert brand.color.to_dict(include="all") == {
+        "red": "#f00",
+        "green": "#0f0",
+        "blue": "#00f",
+        "azul": "#00f",
+        "primary": "#f00",
+        "secondary": "#0f0",
+        "tertiary": "#00f",  # brand.color.tertiary wins!
     }

--- a/pkg-py/tests/test_color.py
+++ b/pkg-py/tests/test_color.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from brand_yml import Brand
+from brand_yml import Brand, BrandColor
 from syrupy.extensions.json import JSONSnapshotExtension
 from utils import path_examples, pydantic_data_from_json
 
@@ -83,3 +83,43 @@ def test_brand_color_ex_palette_internal(snapshot_json):
     }
 
     assert snapshot_json == pydantic_data_from_json(brand)
+
+
+def test_brand_color_defs():
+    brand = Brand.from_yaml_str(
+        """
+        color:
+          palette:
+            red: "#f00"
+            green: "#0f0"
+            blue: "#00f"
+            azul: blue
+          primary: red
+          secondary: green
+          tertiary: blue
+        """
+    )
+
+    assert isinstance(brand.color, BrandColor)
+    assert brand.color._color_defs(include="theme") == {
+        "primary": "#f00",
+        "secondary": "#0f0",
+        "tertiary": "#00f",
+    }
+
+    assert brand.color._color_defs(include="theme") == {
+        "primary": "#f00",
+        "secondary": "#0f0",
+        "tertiary": "#00f",
+    }
+
+    assert brand.color.palette is not None
+    # color palette values are resolved on model validation (may change)
+    assert brand.color.palette["azul"] == "#00f"
+
+    assert brand.color._color_defs(include="palette") == {
+        "red": "#f00",
+        "green": "#0f0",
+        "blue": "#00f",
+        "azul": "#00f",
+    }


### PR DESCRIPTION
* Renames `BrandColor._color_defs()` to `BrandColor.to_dict()`.
* Removes `resolved` argument, colors are always resolved on model validation now. (We may revisit this in the future and we can add the argument back then.)
* Adds `include` parameter, that can return `"all"` colors or just the `"theme"` or `"palette"` colors.