### PR TITLE
fix(docs): Fix view source link

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -19,6 +19,7 @@ website:
 
   repo-url: https://github.com/posit-dev/brand-yml/
   repo-actions: [issue, source]
+  repo-subdir: docs
 
   navbar:
     left:

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -18,7 +18,7 @@ website:
   bread-crumbs: true
 
   repo-url: https://github.com/posit-dev/brand-yml/
-  repo-actions: [issue, source]
+  repo-actions: [issue, edit]
   repo-subdir: docs
 
   navbar:

--- a/docs/pkg/py/_metadata.yml
+++ b/docs/pkg/py/_metadata.yml
@@ -6,3 +6,5 @@ filters:
 format:
   html:
     css: quartodoc.css
+
+repo-actions: false

--- a/docs/pkg/py/index.qmd
+++ b/docs/pkg/py/index.qmd
@@ -4,6 +4,8 @@ title: Brand YAML Python Package
 links:
   pypi: https://pypi.org/project/brand-yml/
   github: https://github.com/posit-dev/brand-yml
+
+repo-actions: true
 ---
 
 ```{=html}


### PR DESCRIPTION
Replaced with "edit" link and correctly setting `repo-subdir` to find the correct source file location.

I removed repo links from the python documentation because they would otherwise link to `.qmd` files that are generated from the python docstrings.

Fixes #44 

c.f. https://quarto.org/docs/websites/website-navigation.html#github-links