### PR TITLE
feat(logo): Add `.to_html()` method for logo resources

### DIFF
--- a/docs/_brand.yml
+++ b/docs/_brand.yml
@@ -138,3 +138,14 @@ defaults:
           color: white;
         }
       }
+
+      #quarto-document-content {
+        section.level1:not(:last-of-type) {
+          border-bottom: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
+          padding-bottom: 2rem;
+        }
+
+        section.level1:not(:last-of-type) > :last-child {
+          margin-bottom: 0;
+        }
+      }

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -136,8 +136,9 @@ quartodoc:
             name: Logos and Images
           contents:
             - BrandLogo
+            - logo.BrandLogoFileType
             - BrandLogoResource
-            - BrandLightDark
+            - BrandLogoLightDarkResource
             - FileLocation
             - FileLocationLocal
             - FileLocationUrl

--- a/docs/pkg/py/Brand.qmd
+++ b/docs/pkg/py/Brand.qmd
@@ -1,7 +1,7 @@
 # Brand { #brand_yml.Brand }
 
 ```python
-Brand()
+Brand(self, /, **data)
 ```
 
 Brand guidelines in a class.

--- a/docs/pkg/py/color.qmd
+++ b/docs/pkg/py/color.qmd
@@ -5,7 +5,7 @@
 # BrandColor { #brand_yml.BrandColor }
 
 ```python
-BrandColor()
+BrandColor(self, /, **data)
 ```
 
 Brand Colors

--- a/docs/pkg/py/logo.qmd
+++ b/docs/pkg/py/logo.qmd
@@ -5,7 +5,7 @@
 # BrandLogo { #brand_yml.BrandLogo }
 
 ```python
-BrandLogo()
+BrandLogo(self, /, **data)
 ```
 
 Brand Logos
@@ -15,7 +15,7 @@ points and possibly in different color schemes. Store all of your brand's
 logo or image assets in `images` with meaningful names. Logos can be mapped
 to three preset sizes -- `small`, `medium`, and `large` -- and each can be
 either a single logo file or a light/dark variant
-(`brand_yml.BrandLightDark`).
+([brand_yml.BrandLightDark](`brand_yml.BrandLightDark`)).
 
 To attach alternative text to an image, provide the image as a dictionary
 including `path` (the image location) and `alt` (the short, alternative
@@ -144,10 +144,72 @@ logo:
 
 :::
 
+## Methods
+
+| Name | Description |
+| --- | --- |
+| [to_html](#brand_yml.BrandLogo.to_html) | Generate an HTML `img` tag or a set of `img` tags |
+
+### to_html { #brand_yml.BrandLogo.to_html }
+
+```python
+BrandLogo.to_html(
+    which,
+    selectors={'light': ['[data-bs-theme="light"]', '.quarto-light'], 'dark': ['[data-bs-theme="dark"]', '.quarto-dark']},
+    **kwargs,
+)
+```
+
+Generate an HTML `img` tag or a set of `img` tags
+
+Creates an HTML `<img>` tag for the brand logo resource named by `which`
+or a set of `<img>` tags if the resource includes light/dark variants.
+
+#### Parameters {.doc-section .doc-section-parameters}
+
+<code><span class="parameter-name">which</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Literal](`typing.Literal`)\[\'small\', \'medium\', \'large\', \'smallest\', \'largest\'\] \| [str](`str`)</span></code>
+
+:   The image to include by name. In addition to the named sizes---
+    `"small"`, `"medium"` and `"large"`---`which` can be `"smallest"` or
+    `"largest"` for the smallest or largest size available, or `which`
+    can be the name of a named image in the `logo.images` dictionary.
+
+<code><span class="parameter-name">selectors</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Literal](`typing.Literal`)\[\'prefers-color-scheme\'\] \| [dict](`dict`)\[[str](`str`), [str](`str`) \| [list](`list`)\[[str](`str`)\]\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">{'light': ['[data-bs-theme="light"]', '.quarto-light'], 'dark': ['[data-bs-theme="dark"]', '.quarto-dark']}</span></code>
+
+:   CSS selectors used to indicate that light or dark mode is active.
+    Use `selectors="prefers-color-scheme"` for a variant that uses
+    media queries associated with the system color scheme, rather than
+    specific CSS selectors.
+
+<code><span class="parameter-name">**kwargs</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[htmltools](`htmltools`).[TagAttrValue](`htmltools.TagAttrValue`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">{}</span></code>
+
+:   Additional keyword arguments to be passed to the img tag.
+
+#### Returns {.doc-section .doc-section-returns}
+
+| Name   | Type                                                                                                                                | Description                                                                                                                                                                                                                                                |
+|--------|-------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|        | [Union](`typing.Union`)\[[htmltools](`htmltools`).[Tag](`htmltools.Tag`), [htmltools](`htmltools`).[TagList](`htmltools.TagList`)\] | Returns an HTML `<img>` tag for a singular [](`brand_yml.BrandLogoResource`) or two HTML `<img>` tags with additional CSS to selectively hide the light or dark images when in the opposite color scheme for a [](`brand_yml.BrandLogoLightDarkResource`). |
+
+#### See also {.doc-section .doc-section-see-also}
+
+
+- [BrandLogoResource.to_html](`brand_yml.BrandLogoResource.to_html`)
+- [BrandLogoLightDarkResource.to_html](`brand_yml.BrandLogoLightDarkResource.to_html`)
+
+# logo.BrandLogoFileType { #brand_yml.logo.BrandLogoFileType }
+
+`logo.BrandLogoFileType`
+
+A logo image file can be either a local or URL file location with optional
+alternative text ([](`brand_yml.BrandLogoResource`)) or a light-dark variant
+that includes both a light and dark color scheme
+([](`brand_yml.BrandLogoLightDarkResource`)).
+
 # BrandLogoResource { #brand_yml.BrandLogoResource }
 
 ```python
-BrandLogoResource()
+BrandLogoResource(self, /, **data)
 ```
 
 A logo resource, a file with optional alternative text
@@ -159,31 +221,162 @@ A logo resource, a file with optional alternative text
 | [alt](#brand_yml.logo.BrandLogoResource.alt) | Alterative text for the image, used for accessibility. |
 | [path](#brand_yml.logo.BrandLogoResource.path) | The path to the logo resource. This can be a local file or a URL. |
 
-# BrandLightDark { #brand_yml.BrandLightDark }
-
-```python
-BrandLightDark()
-```
-
-A Light/Dark Variant
-
-Holds variants for light and dark settings. Generally speaking **light**
-settings have white or light backgrounds and dark foreground colors
-(black text on a white page) and **dark** settings use black or dark
-background with light foreground colors (white text on a black page).
-
-## Attributes
+## Methods
 
 | Name | Description |
 | --- | --- |
-| [dark](#brand_yml._defs.BrandLightDark.dark) | Value in dark mode. |
-| [light](#brand_yml._defs.BrandLightDark.light) | Value in light mode. |
+| [to_html](#brand_yml.BrandLogoResource.to_html) | Generate an HTML img tag for the logo resource. |
 
+### to_html { #brand_yml.BrandLogoResource.to_html }
+
+```python
+BrandLogoResource.to_html(selectors=None, which='', **kwargs)
+```
+
+Generate an HTML img tag for the logo resource.
+
+This method creates an HTML img tag based on the logo's path and
+alternative text. If the logo is stored locally, it will be converted to
+a data URI. For remote logos, the source URL will be used directly.
+
+#### Parameters {.doc-section .doc-section-parameters}
+
+<code><span class="parameter-name">selectors</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Literal](`typing.Literal`)\[\'prefers-color-scheme\'\] \| [dict](`dict`)\[[str](`str`), [str](`str`) \| [list](`list`)\[[str](`str`)\]\] \| None</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+
+:   Ignored, included for stable function signature across logo
+    variations.
+
+<code><span class="parameter-name">which</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[str](`str`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">''</span></code>
+
+:   Ignored, included for stable function signature across logo
+    variations.
+
+<code><span class="parameter-name">**kwargs</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[htmltools](`htmltools`).[TagAttrValue](`htmltools.TagAttrValue`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">{}</span></code>
+
+:   Additional keyword arguments to be passed to the img tag.
+
+#### Returns {.doc-section .doc-section-returns}
+
+| Name   | Type                                            | Description                            |
+|--------|-------------------------------------------------|----------------------------------------|
+|        | [htmltools](`htmltools`).[Tag](`htmltools.Tag`) | An HTML img tag representing the logo. |
+
+#### Examples {.doc-section .doc-section-examples}
+
+```{python}
+from brand_yml import BrandLogoResource
+small = BrandLogoResource(
+    path="../../logos/icon/brand-yml-icon-color.png",
+    alt="brand.yml icon"
+)
+print(small.to_html(class_="my-brand-icon"))
+```
+
+```{python}
+small = BrandLogoResource(
+    path="https://posit-dev.github.io/brand-yml/logos/icon/brand-yml-icon-color.png",
+    alt="brand.yml remote icon"
+)
+small.to_html(width="32px", height="32px")
+```
+
+# BrandLogoLightDarkResource { #brand_yml.BrandLogoLightDarkResource }
+
+```python
+BrandLogoLightDarkResource(self, /, **data)
+```
+
+A pair of light and dark logo resources
+
+## Methods
+
+| Name | Description |
+| --- | --- |
+| [to_html](#brand_yml.BrandLogoLightDarkResource.to_html) | Generate a set of HTML img tags for the light/dark logo resource. |
+
+### to_html { #brand_yml.BrandLogoLightDarkResource.to_html }
+
+```python
+BrandLogoLightDarkResource.to_html(
+    selectors={'light': ['[data-bs-theme="light"]', '.quarto-light'], 'dark': ['[data-bs-theme="dark"]', '.quarto-dark']},
+    which='',
+    **kwargs,
+)
+```
+
+Generate a set of HTML img tags for the light/dark logo resource.
+
+This method creates a pair of HTML img tags for each of the `light` and
+`dark` logo variants using the logo's path and alternative text. If the
+logo image is stored locally, it will be converted to a data URI. For
+remote logos, the source URL will be used directly.
+
+Additional CSS is included to ensure that the `light` logo is shown when
+a light color scheme is used (dark text on a light background) and the
+`dark` logo is shown when a dark color scheme is used (light text on a
+dark background).
+
+#### Parameters {.doc-section .doc-section-parameters}
+
+<code><span class="parameter-name">selectors</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Literal](`typing.Literal`)\[\'prefers-color-scheme\'\] \| [dict](`dict`)\[[str](`str`), [str](`str`) \| [list](`list`)\[[str](`str`)\]\] \| None</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">{'light': ['[data-bs-theme="light"]', '.quarto-light'], 'dark': ['[data-bs-theme="dark"]', '.quarto-dark']}</span></code>
+
+:   CSS selectors used to indicate that light or dark mode is active.
+    Use `selectors="prefers-color-scheme"` for a variant that uses
+    media queries associated with the system color scheme, rather than
+    specific CSS selectors.
+
+<code><span class="parameter-name">which</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[str](`str`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">''</span></code>
+
+:   Ignored, included for stable function signature across logo
+    variations.
+
+<code><span class="parameter-name">**kwargs</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[htmltools](`htmltools`).[TagAttrValue](`htmltools.TagAttrValue`)</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">{}</span></code>
+
+:   Additional keyword arguments to be passed to the img tag.
+
+#### Returns {.doc-section .doc-section-returns}
+
+| Name   | Type                                                    | Description                                                                                                               |
+|--------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+|        | [htmltools](`htmltools`).[TagList](`htmltools.TagList`) | Two HTML `<img>` tags with additional CSS to selectively hide the light or dark images when in the opposite color scheme. |
+
+#### Examples {.doc-section .doc-section-examples}
+
+```{python}
+from brand_yml import BrandLogoLightDarkResource
+small = BrandLogoLightDarkResource(
+    light = BrandLogoResource(
+        path="../../logos/icon/brand-yml-icon-black.png",
+        alt="brand.yml remote icon (light)"
+    ),
+    dark = BrandLogoResource(
+        path="../../logos/icon/brand-yml-icon-color.png",
+        alt="brand.yml remote icon (dark)"
+    )
+)
+
+for item in small.to_html():  # `.to_html()` returns an `htmltools.TagList()`
+    print(item)
+```
+
+```{python}
+small = BrandLogoLightDarkResource(
+    light = BrandLogoResource(
+        path="https://posit-dev.github.io/brand-yml/logos/icon/brand-yml-icon-black.png",
+        alt="brand.yml remote icon (light)"
+    ),
+    dark = BrandLogoResource(
+        path="https://posit-dev.github.io/brand-yml/logos/icon/brand-yml-icon-color.png",
+        alt="brand.yml remote icon (dark)"
+    )
+)
+small.to_html(width="32px", height="32px")
+```
 
 # FileLocation { #brand_yml.FileLocation }
 
 ```python
-FileLocation()
+FileLocation(self, /, root=PydanticUndefined, **data)
 ```
 
 The base class for a file location, either a local or an online file.
@@ -201,7 +394,7 @@ local or network files are supported via `FileLocationUrl` when using the
 # FileLocationLocal { #brand_yml.FileLocationLocal }
 
 ```python
-FileLocationLocal()
+FileLocationLocal(self, /, root=PydanticUndefined, **data)
 ```
 
 A local file location.
@@ -279,7 +472,7 @@ Validate that the file exists at its absolute path.
 # FileLocationUrl { #brand_yml.FileLocationUrl }
 
 ```python
-FileLocationUrl()
+FileLocationUrl(self, /, root=PydanticUndefined, **data)
 ```
 
 A hosted, online file location, i.e. a URL.

--- a/docs/pkg/py/meta.qmd
+++ b/docs/pkg/py/meta.qmd
@@ -5,7 +5,7 @@
 # BrandMeta { #brand_yml.BrandMeta }
 
 ```python
-BrandMeta()
+BrandMeta(self, /, **data)
 ```
 
 Brand Metadata
@@ -101,7 +101,7 @@ meta:
 # meta.BrandMetaName { #brand_yml.meta.BrandMetaName }
 
 ```python
-meta.BrandMetaName()
+meta.BrandMetaName(self, /, **data)
 ```
 
 
@@ -116,7 +116,7 @@ meta.BrandMetaName()
 # meta.BrandMetaLink { #brand_yml.meta.BrandMetaLink }
 
 ```python
-meta.BrandMetaLink()
+meta.BrandMetaLink(self, /, **data)
 ```
 
 Brand Metadata Links

--- a/docs/pkg/py/typography.qmd
+++ b/docs/pkg/py/typography.qmd
@@ -5,7 +5,7 @@
 # BrandTypography { #brand_yml.BrandTypography }
 
 ```python
-BrandTypography()
+BrandTypography(self, /, **data)
 ```
 
 Represents the typographic choices of a brand.
@@ -249,9 +249,9 @@ defined in the typography configuration.
 
 ```python
 BrandTypography.fonts_html_dependency(
-    path_dir
-    name='brand-fonts'
-    version='0.0.1'
+    path_dir,
+    name='brand-fonts',
+    version='0.0.1',
 )
 ```
 
@@ -354,7 +354,7 @@ choices in brand guidelines.
 ### BrandTypographyFontSource { #brand_yml.typography.BrandTypographyFontSource }
 
 ```python
-typography.BrandTypographyFontSource()
+typography.BrandTypographyFontSource(self, /, **data)
 ```
 
 A base class representing a font source.
@@ -386,7 +386,7 @@ Create the CSS declarations needed to use the font family.
 ### BrandTypographyFontFiles { #brand_yml.typography.BrandTypographyFontFiles }
 
 ```python
-typography.BrandTypographyFontFiles()
+typography.BrandTypographyFontFiles(self, /, **data)
 ```
 
 A font family defined by a collection of font files.
@@ -423,7 +423,7 @@ typography:
 ### BrandTypographyFontGoogle { #brand_yml.typography.BrandTypographyFontGoogle }
 
 ```python
-typography.BrandTypographyFontGoogle()
+typography.BrandTypographyFontGoogle(self, /, **data)
 ```
 
 A font family provided by Google Fonts.
@@ -454,7 +454,7 @@ Slab font is sourced from Google Fonts with three specific font weights --
 ### BrandTypographyFontBunny { #brand_yml.typography.BrandTypographyFontBunny }
 
 ```python
-typography.BrandTypographyFontBunny()
+typography.BrandTypographyFontBunny(self, /, **data)
 ```
 
 A font family provided by Bunny Fonts.
@@ -484,7 +484,7 @@ typography:
 ### BrandTypographyGoogleFontsApi { #brand_yml.typography.BrandTypographyGoogleFontsApi }
 
 ```python
-typography.BrandTypographyGoogleFontsApi()
+typography.BrandTypographyGoogleFontsApi(self, /, **data)
 ```
 
 A font source that utilizes the Google Fonts (or a compatible) API.
@@ -520,7 +520,12 @@ Returns the URL for the font family to be used in a CSS `@import` statement.
 ### BrandTypographyGoogleFontsWeightRange { #brand_yml.typography.BrandTypographyGoogleFontsWeightRange }
 
 ```python
-typography.BrandTypographyGoogleFontsWeightRange()
+typography.BrandTypographyGoogleFontsWeightRange(
+    self,
+    /,
+    root=PydanticUndefined,
+    **data,
+)
 ```
 
 Represents a range of font weights for Google Fonts.
@@ -554,27 +559,27 @@ root
 
 | Name | Description |
 | --- | --- |
-| [model_dump](#brand_yml.typography.BrandTypographyGoogleFontsWeightRange.model_dump) | Usage docs: https://docs.pydantic.dev/2.9/concepts/serialization/#modelmodel_dump |
+| [model_dump](#brand_yml.typography.BrandTypographyGoogleFontsWeightRange.model_dump) | Usage docs: https://docs.pydantic.dev/2.10/concepts/serialization/#modelmodel_dump |
 
 ##### model_dump { #brand_yml.typography.BrandTypographyGoogleFontsWeightRange.model_dump }
 
 ```python
 typography.BrandTypographyGoogleFontsWeightRange.model_dump(
-    mode='python'
-    include=None
-    exclude=None
-    context=None
-    by_alias=False
-    exclude_unset=False
-    exclude_defaults=False
-    exclude_none=False
-    round_trip=False
-    warnings=True
-    serialize_as_any=False
+    mode='python',
+    include=None,
+    exclude=None,
+    context=None,
+    by_alias=False,
+    exclude_unset=False,
+    exclude_defaults=False,
+    exclude_none=False,
+    round_trip=False,
+    warnings=True,
+    serialize_as_any=False,
 )
 ```
 
-Usage docs: https://docs.pydantic.dev/2.9/concepts/serialization/#modelmodel_dump
+Usage docs: https://docs.pydantic.dev/2.10/concepts/serialization/#modelmodel_dump
 
 Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.
 
@@ -600,7 +605,7 @@ Returns:
 ### BrandTypographyBase { #brand_yml.typography.BrandTypographyBase }
 
 ```python
-typography.BrandTypographyBase()
+typography.BrandTypographyBase(self, /, **data)
 ```
 
 Typographic settings for base (or body) text.
@@ -637,26 +642,34 @@ brand.typography.model_dump(
 
 family
 
-:   The font family to be used. Note that the font family name should match
+:   [str](`str`) \| None
+
+    The font family to be used. Note that the font family name should match
     a resource in `typography.fonts`.
 
 weight
 
-:   The font weight (boldness) of the text.
+:   [BrandTypographyFontWeightSimpleType](`brand_yml.typography.BrandTypographyFontWeightSimpleType`) \| None
+
+    The font weight (boldness) of the text.
 
 size
 
-:   The font size of the text. Should be a CSS length unit (e.g., 14px).
+:   [str](`str`) \| None
+
+    The font size of the text. Should be a CSS length unit (e.g., 14px).
 
 line_height
 
-:   The line height of the text. Line height refers to the vertical space
+:   [float](`float`) \| None
+
+    The line height of the text. Line height refers to the vertical space
     between lines of text.
 
 ### BrandTypographyHeadings { #brand_yml.typography.BrandTypographyHeadings }
 
 ```python
-typography.BrandTypographyHeadings()
+typography.BrandTypographyHeadings(self, /, **data)
 ```
 
 Typographic settings for headings and titles.
@@ -665,26 +678,36 @@ Typographic settings for headings and titles.
 
 family
 
-:   The font family used for headings. Note that this should match a resource
+:   [str](`str`) \| None
+
+    The font family used for headings. Note that this should match a resource
     in `typography.fonts`.
 
 weight
 
-:   The font weight (or boldness) of the text.
+:   [BrandTypographyFontWeightSimpleType](`brand_yml.typography.BrandTypographyFontWeightSimpleType`) \| None
+
+    The font weight (or boldness) of the text.
 
 style
 
-:   The font style for the heading, i.e., whether it should be styled in a
+:   [SingleOrList](`brand_yml.typography.SingleOrList`)\[[BrandTypographyFontStyleType](`brand_yml.typography.BrandTypographyFontStyleType`)\] \| None
+
+    The font style for the heading, i.e., whether it should be styled in a
     `"normal"` or `"italic"` style.
 
 line_height
 
-:   The line height of the heading. Line height refers to the vertical space
+:   [float](`float`) \| None
+
+    The line height of the heading. Line height refers to the vertical space
     between lines of text.
 
 color
 
-:   The color of the text.
+:   [str](`str`) \| None
+
+    The color of the text.
 
 #### Examples {.doc-section .doc-section-examples}
 
@@ -702,7 +725,7 @@ typography:
 ### BrandTypographyMonospace { #brand_yml.typography.BrandTypographyMonospace }
 
 ```python
-typography.BrandTypographyMonospace()
+typography.BrandTypographyMonospace(self, /, **data)
 ```
 
 Typographic settings for monospace text.
@@ -719,17 +742,23 @@ respectively.
 
 family
 
-:   The font family to be used for monospace text. Note that the font family
+:   [str](`str`) \| None
+
+    The font family to be used for monospace text. Note that the font family
     name should match a resource in `typography.fonts`.
 
 weight
 
-:   The font weight (boldness) of the monospace text. Can be a numeric value
+:   [BrandTypographyFontWeightSimpleType](`brand_yml.typography.BrandTypographyFontWeightSimpleType`) \| None
+
+    The font weight (boldness) of the monospace text. Can be a numeric value
     between 100 and 900, or a string like "normal" or "bold".
 
 size
 
-:   The font size of the monospace text. Should be a CSS length unit
+:   [str](`str`) \| None
+
+    The font size of the monospace text. Should be a CSS length unit
     (e.g., "0.9em", "14px").
 
 #### Examples {.doc-section .doc-section-examples}
@@ -776,7 +805,7 @@ typography:
 ### BrandTypographyMonospaceInline { #brand_yml.typography.BrandTypographyMonospaceInline }
 
 ```python
-typography.BrandTypographyMonospaceInline()
+typography.BrandTypographyMonospaceInline(self, /, **data)
 ```
 
 Typographic settings for inline monospace text.
@@ -791,28 +820,38 @@ with additional options for foreground and background colors.
 
 family
 
-:   The font family to be used for inline monospace text. Note that the font
+:   [str](`str`) \| None
+
+    The font family to be used for inline monospace text. Note that the font
     family name should match a resource in `typography.fonts`.
 
 weight
 
-:   The font weight (boldness) of the inline monospace text. Can be a
+:   [BrandTypographyFontWeightSimpleType](`brand_yml.typography.BrandTypographyFontWeightSimpleType`) \| None
+
+    The font weight (boldness) of the inline monospace text. Can be a
     numeric value between 100 and 900, or a string like "normal" or "bold".
 
 size
 
-:   The font size of the inline monospace text. Should be a CSS length unit
+:   [str](`str`) \| None
+
+    The font size of the inline monospace text. Should be a CSS length unit
     (e.g., "0.9em", "14px").
 
 color
 
-:   The color of the inline monospace text. Can be any CSS-compatible color
+:   [str](`str`) \| None
+
+    The color of the inline monospace text. Can be any CSS-compatible color
     definition or a reference to a color defined in the brand's color
     palette.
 
 background_color
 
-:   The background color of the inline monospace text. Can be any
+:   [str](`str`) \| None
+
+    The background color of the inline monospace text. Can be any
     CSS-compatible color definition or a reference to a color defined in the
     brand's color palette.
 
@@ -853,7 +892,7 @@ typography:
 ### BrandTypographyMonospaceBlock { #brand_yml.typography.BrandTypographyMonospaceBlock }
 
 ```python
-typography.BrandTypographyMonospaceBlock()
+typography.BrandTypographyMonospaceBlock(self, /, **data)
 ```
 
 Typographic settings for block monospace text.
@@ -868,33 +907,45 @@ and adds options for line height, foreground color, and background color.
 
 family
 
-:   The font family to be used for block monospace text. Note that the font
+:   [str](`str`) \| None
+
+    The font family to be used for block monospace text. Note that the font
     family name should match a resource in `typography.fonts`.
 
 weight
 
-:   The font weight (boldness) of the block monospace text. Can be a
+:   [BrandTypographyFontWeightSimpleType](`brand_yml.typography.BrandTypographyFontWeightSimpleType`) \| None
+
+    The font weight (boldness) of the block monospace text. Can be a
     numeric value between 100 and 900, or a string like "normal" or "bold".
 
 size
 
-:   The font size of the block monospace text. Should be a CSS length unit
+:   [str](`str`) \| None
+
+    The font size of the block monospace text. Should be a CSS length unit
     (e.g., "0.9em", "14px").
 
 line_height
 
-:   The line height of the block monospace text. Line height refers to the
+:   [float](`float`) \| None
+
+    The line height of the block monospace text. Line height refers to the
     vertical space between lines of text.
 
 color
 
-:   The color of the block monospace text. Can be any CSS-compatible color
+:   [str](`str`) \| None
+
+    The color of the block monospace text. Can be any CSS-compatible color
     definition or a reference to a color defined in the brand's color
     palette.
 
 background_color
 
-:   The background color of the block monospace text. Can be any
+:   [str](`str`) \| None
+
+    The background color of the block monospace text. Can be any
     CSS-compatible color definition or a reference to a color defined in the
     brand's color palette.
 
@@ -921,7 +972,7 @@ typography:
 ### BrandTypographyLink { #brand_yml.typography.BrandTypographyLink }
 
 ```python
-typography.BrandTypographyLink()
+typography.BrandTypographyLink(self, /, **data)
 ```
 
 Typographic settings for hyperlinks.
@@ -933,18 +984,24 @@ of font weight, colors, and text decoration.
 
 weight
 
-:   The font weight (boldness) of the hyperlink text. Can be a numeric value
+:   [BrandTypographyFontWeightSimpleType](`brand_yml.typography.BrandTypographyFontWeightSimpleType`) \| None
+
+    The font weight (boldness) of the hyperlink text. Can be a numeric value
     between 100 and 900, or a string like "normal" or "bold".
 
 color
 
-:   The color of the hyperlink text. Can be any CSS-compatible color
+:   [str](`str`) \| None
+
+    The color of the hyperlink text. Can be any CSS-compatible color
     definition or a reference to a color defined in the brand's color
     palette.
 
 background_color
 
-:   The background color of the hyperlink text. Can be any CSS-compatible
+:   [str](`str`) \| None
+
+    The background color of the hyperlink text. Can be any CSS-compatible
     color definition or a reference to a color defined in the brand's color
     palette.
 

--- a/pkg-py/src/brand_yml/__init__.py
+++ b/pkg-py/src/brand_yml/__init__.py
@@ -17,7 +17,7 @@ from ._utils_yaml import yaml_brand as yaml
 from .base import BrandBase
 from .color import BrandColor
 from .file import FileLocation, FileLocationLocal, FileLocationUrl
-from .logo import BrandLogo, BrandLogoResource
+from .logo import BrandLogo, BrandLogoLightDarkResource, BrandLogoResource
 from .meta import BrandMeta
 from .typography import BrandTypography
 
@@ -373,6 +373,7 @@ __all__ = [
     "BrandTypography",
     "BrandLightDark",
     "BrandLogoResource",
+    "BrandLogoLightDarkResource",
     "FileLocation",
     "FileLocationLocal",
     "FileLocationUrl",

--- a/pkg-py/src/brand_yml/logo.py
+++ b/pkg-py/src/brand_yml/logo.py
@@ -8,10 +8,14 @@ or online, possibly with light or dark variants.
 from __future__ import annotations
 
 from pathlib import Path
+from textwrap import dedent
 from typing import Annotated, Any, Literal, Union
 
+import htmltools
+from datauri import DataURI
 from pydantic import (
     AnyUrl,
+    BaseModel,
     ConfigDict,
     Discriminator,
     Tag,
@@ -22,7 +26,11 @@ from pydantic import (
 from ._defs import BrandLightDark, defs_replace_recursively
 from ._utils_docs import add_example_yaml
 from .base import BrandBase
-from .file import FileLocation, FileLocationLocalOrUrlType
+from .file import (
+    FileLocation,
+    FileLocationLocal,
+    FileLocationLocalOrUrlType,
+)
 
 
 class BrandLogoResource(BrandBase):
@@ -40,6 +48,234 @@ class BrandLogoResource(BrandBase):
 
     alt: str | None = None
     """Alterative text for the image, used for accessibility."""
+
+    def as_data_uri(self) -> str:
+        if not isinstance(self.path, FileLocationLocal):
+            return ""
+        return str(DataURI.from_file(str(self.path.absolute())))
+
+    def to_html(
+        self,
+        *,
+        selectors: Literal["prefers-color-scheme"]
+        | dict[str, str | list[str]]
+        | None = None,
+        which: str = "",
+        **kwargs: htmltools.TagAttrValue,
+    ) -> htmltools.Tag:
+        """
+        Generate an HTML img tag for the logo resource.
+
+        This method creates an HTML img tag based on the logo's path and
+        alternative text. If the logo is stored locally, it will be converted to
+        a data URI. For remote logos, the source URL will be used directly.
+
+        Parameters
+        ----------
+        selectors
+            Ignored, included for stable function signature across logo
+            variations.
+        which
+            Ignored, included for stable function signature across logo
+            variations.
+        **kwargs
+            Additional keyword arguments to be passed to the img tag.
+
+        Returns
+        -------
+        :
+            An HTML img tag representing the logo.
+
+        Examples
+        --------
+
+        ```{python}
+        from brand_yml import BrandLogoResource
+        small = BrandLogoResource(
+            path="../../logos/icon/brand-yml-icon-color.png",
+            alt="brand.yml icon"
+        )
+        print(small.to_html(class_="my-brand-icon"))
+        ```
+
+        ```{python}
+        small = BrandLogoResource(
+            path="https://posit-dev.github.io/brand-yml/logos/icon/brand-yml-icon-color.png",
+            alt="brand.yml remote icon"
+        )
+        small.to_html(width="32px", height="32px")
+        ```
+        """
+        if isinstance(self.path, FileLocationLocal):
+            return htmltools.img(**kwargs, alt=self.alt, src=self.as_data_uri())
+
+        return htmltools.img(**kwargs, src=str(self.path), alt=self.alt or "")
+
+    def tagify(self) -> htmltools.TagList:
+        return htmltools.TagList(self.to_html())
+
+
+class BrandLightDarkSelectors(BaseModel):
+    light: list[str] = ['[data-bs-theme="light"]', ".quarto-light"]
+    dark: list[str] = ['[data-bs-theme="dark"]', ".quarto-dark"]
+
+    @field_validator("light", "dark")
+    @classmethod
+    def _validate_light_dark(cls, value: Any):
+        if not isinstance(value, list):
+            return [value]
+        return value
+
+
+def light_dark_css(
+    selectors: Literal["prefers-color-scheme"]
+    | dict[str, str | list[str]]
+    | BrandLightDarkSelectors = BrandLightDarkSelectors(),
+) -> str:
+    if isinstance(selectors, dict):
+        selectors = BrandLightDarkSelectors.model_validate(selectors)
+
+    if selectors == "prefers-color-scheme":
+        light_dark_css = """
+        @media not all and (prefers-color-scheme: dark) {
+            [data-when-theme="dark"] {
+                display: none;
+            }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            [data-when-theme="light"] {
+                display: none;
+            }
+        }
+        """
+    else:
+        selectors_strs = [
+            *[f'{s} [data-when-theme="dark"]' for s in selectors.light],
+            *[f'{s} [data-when-theme="light"]' for s in selectors.dark],
+        ]
+        light_dark_css = f"""
+        {', '.join(selectors_strs)} {{
+            display: none;
+        }}
+        """
+
+    return dedent(light_dark_css)
+
+
+class BrandLogoLightDarkResource(BrandLightDark[BrandLogoResource]):
+    """A pair of light and dark logo resources"""
+
+    def to_html(
+        self,
+        *,
+        selectors: Literal["prefers-color-scheme"]
+        | dict[str, str | list[str]]
+        | None = {
+            "light": ['[data-bs-theme="light"]', ".quarto-light"],
+            "dark": ['[data-bs-theme="dark"]', ".quarto-dark"],
+        },
+        which: str = "",
+        **kwargs: htmltools.TagAttrValue,
+    ) -> htmltools.TagList:
+        """
+        Generate a set of HTML img tags for the light/dark logo resource.
+
+        This method creates a pair of HTML img tags for each of the `light` and
+        `dark` logo variants using the logo's path and alternative text. If the
+        logo image is stored locally, it will be converted to a data URI. For
+        remote logos, the source URL will be used directly.
+
+        Additional CSS is included to ensure that the `light` logo is shown when
+        a light color scheme is used (dark text on a light background) and the
+        `dark` logo is shown when a dark color scheme is used (light text on a
+        dark background).
+
+        Parameters
+        ----------
+        selectors
+            CSS selectors used to indicate that light or dark mode is active.
+            Use `selectors="prefers-color-scheme"` for a variant that uses
+            media queries associated with the system color scheme, rather than
+            specific CSS selectors.
+        which
+            Ignored, included for stable function signature across logo
+            variations.
+        **kwargs
+            Additional keyword arguments to be passed to the img tag.
+
+        Returns
+        -------
+        :
+            Two HTML `<img>` tags with additional CSS to selectively hide the
+            light or dark images when in the opposite color scheme.
+
+        Examples
+        --------
+
+        ```{python}
+        from brand_yml import BrandLogoLightDarkResource
+        small = BrandLogoLightDarkResource(
+            light = BrandLogoResource(
+                path="../../logos/icon/brand-yml-icon-black.png",
+                alt="brand.yml remote icon (light)"
+            ),
+            dark = BrandLogoResource(
+                path="../../logos/icon/brand-yml-icon-color.png",
+                alt="brand.yml remote icon (dark)"
+            )
+        )
+
+        for item in small.to_html():  # `.to_html()` returns an `htmltools.TagList()`
+            print(item)
+        ```
+
+        ```{python}
+        small = BrandLogoLightDarkResource(
+            light = BrandLogoResource(
+                path="https://posit-dev.github.io/brand-yml/logos/icon/brand-yml-icon-black.png",
+                alt="brand.yml remote icon (light)"
+            ),
+            dark = BrandLogoResource(
+                path="https://posit-dev.github.io/brand-yml/logos/icon/brand-yml-icon-color.png",
+                alt="brand.yml remote icon (dark)"
+            )
+        )
+        small.to_html(width="32px", height="32px")
+        ```
+        """
+        light = None
+        dark = None
+
+        if self.light:
+            light = self.light.to_html(
+                selectors=None,
+                which="",
+                **{"data-when-theme": "light"},
+                **kwargs,
+            )
+
+        if self.dark:
+            dark = self.dark.to_html(
+                selectors=None,
+                which="",
+                **{"data-when-theme": "dark"},
+                **kwargs,
+            )
+
+        return htmltools.TagList(
+            # For now we just include the CSS directly. This might result in
+            # the same CSS included more than once, but HTMLDependency doesn't
+            # work in Quarto and py-shiny doesn't support "singletons".
+            htmltools.tags.style(
+                light_dark_css(selectors or BrandLightDarkSelectors())
+            ),
+            light,
+            dark,
+        )
+
+    def tagify(self) -> htmltools.TagList:
+        return self.to_html()
 
 
 def brand_logo_type_discriminator(
@@ -59,26 +295,19 @@ def brand_logo_type_discriminator(
     raise TypeError(f"{type(x)} is not a valid brand logo type")
 
 
-BrandLogoImageType = Union[FileLocationLocalOrUrlType, BrandLogoResource]
-"""
-A logo image file can be either a local or URL file location, or a dictionary
-with `path` and `alt`, the path to the file (local or URL) and an associated
-alternative text for the logo image to be used for accessibility.
-"""
-
-
 BrandLogoFileType = Annotated[
     Union[
         Annotated[BrandLogoResource, Tag("resource")],
-        Annotated[BrandLightDark[BrandLogoResource], Tag("light-dark")],
+        Annotated[BrandLogoLightDarkResource, Tag("light-dark")],
     ],
     Discriminator(brand_logo_type_discriminator),
 ]
-"""
-A logo image file can be either a local or URL file location with optional
-alternative text or a light-dark variant that includes both a light and dark
-color scheme.
-"""
+BrandLogoFileType.__doc__ = """
+    A logo image file can be either a local or URL file location with optional
+    alternative text ([](`brand_yml.BrandLogoResource`)) or a light-dark variant
+    that includes both a light and dark color scheme
+    ([](`brand_yml.BrandLogoLightDarkResource`)).
+    """
 
 
 @add_example_yaml(
@@ -97,7 +326,7 @@ class BrandLogo(BrandBase):
     logo or image assets in `images` with meaningful names. Logos can be mapped
     to three preset sizes -- `small`, `medium`, and `large` -- and each can be
     either a single logo file or a light/dark variant
-    (`brand_yml.BrandLightDark`).
+    ([brand_yml.BrandLightDark](`brand_yml.BrandLightDark`)).
 
     To attach alternative text to an image, provide the image as a dictionary
     including `path` (the image location) and `alt` (the short, alternative
@@ -137,6 +366,111 @@ class BrandLogo(BrandBase):
     small: BrandLogoFileType | None = None
     medium: BrandLogoFileType | None = None
     large: BrandLogoFileType | None = None
+
+    def to_html(
+        self,
+        *,
+        which: Literal["small", "medium", "large", "smallest", "largest"] | str,
+        selectors: Literal["prefers-color-scheme"]
+        | dict[str, str | list[str]] = {
+            "light": ['[data-bs-theme="light"]', ".quarto-light"],
+            "dark": ['[data-bs-theme="dark"]', ".quarto-dark"],
+        },
+        **kwargs: htmltools.TagAttrValue,
+    ) -> Union[htmltools.Tag, htmltools.TagList]:
+        """
+        Generate an HTML `img` tag or a set of `img` tags
+
+        Creates an HTML `<img>` tag for the brand logo resource named by `which`
+        or a set of `<img>` tags if the resource includes light/dark variants.
+
+        Parameters
+        ----------
+        which
+            The image to include by name. In addition to the named sizes---
+            `"small"`, `"medium"` and `"large"`---`which` can be `"smallest"` or
+            `"largest"` for the smallest or largest size available, or `which`
+            can be the name of a named image in the `logo.images` dictionary.
+        selectors
+            CSS selectors used to indicate that light or dark mode is active.
+            Use `selectors="prefers-color-scheme"` for a variant that uses
+            media queries associated with the system color scheme, rather than
+            specific CSS selectors.
+        **kwargs
+            Additional keyword arguments to be passed to the img tag.
+
+        Returns
+        -------
+        :
+            Returns an HTML `<img>` tag for a singular
+            [](`brand_yml.BrandLogoResource`) or two HTML `<img>` tags with
+            additional CSS to selectively hide the light or dark images when in
+            the opposite color scheme for a
+            [](`brand_yml.BrandLogoLightDarkResource`).
+
+        See also
+        --------
+
+        - [BrandLogoResource.to_html](`brand_yml.BrandLogoResource.to_html`)
+        - [BrandLogoLightDarkResource.to_html](`brand_yml.BrandLogoLightDarkResource.to_html`)
+
+        """
+        if which not in ("small", "medium", "large", "smallest", "largest"):
+            if self.images and which in self.images.keys():
+                return self.images[which].to_html(
+                    selectors=selectors,
+                    which="",
+                    **kwargs,
+                )
+            else:
+                raise ValueError(
+                    f"{which} is not an image in `logo.images` "
+                    "nor is it a known size: "
+                    "small, medium, large, smallest, or largest."
+                )
+
+        if which == "smallest":
+            if self.small:
+                which = "small"
+            elif self.medium:
+                which = "medium"
+            elif self.large:
+                which = "large"
+
+        if which == "largest":
+            if self.large:
+                which = "large"
+            elif self.medium:
+                which = "medium"
+            elif self.small:
+                which = "small"
+
+        if which == "small":
+            if not self.small:
+                raise ValueError("This brand does not include a small logo.")
+            return self.small.to_html(selectors=selectors, which="", **kwargs)
+
+        if which == "medium":
+            if not self.medium:
+                raise ValueError("This brand does not include a medium logo.")
+            return self.medium.to_html(selectors=selectors, which="", **kwargs)
+
+        if which == "large":
+            if not self.large:
+                raise ValueError("This brand does not include a large logo.")
+            return self.large.to_html(selectors=selectors, which="", **kwargs)
+
+        raise ValueError("No predefined sizes are included for `brand.logo`.")
+
+    def tagify(self) -> htmltools.TagList:
+        if self.medium:
+            return self.medium.tagify()
+        if self.large:
+            return self.large.tagify()
+        if self.small:
+            return self.small.tagify()
+
+        return htmltools.TagList()
 
     @model_validator(mode="before")
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ dependencies = [
     "ruamel-yaml>=0.18.0",
     "pydantic>=2",
     "eval-type-backport>=0.2.0",
-    "htmltools>=0.2.0"
+    "htmltools>=0.2.0",
+    "python-datauri>=3.0.1",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
Adds a `.to_html()` method to `brand_yml.BrandLogo`, `brand_yml.BrandLogoResource` and `brand_yml.BrandLogoLightDarkResource` (all variants of `brand.logo`, `brand.logo.{small, medium, large}`) to help create an `<img>` tag or a pair of `<img>` tags in the light/dark variant case.

```python
brand.logo.to_html("small")
# equal to...
brand.logo.small.to_html()

# Same for images in `logo.images`
brand.logo.to_html("wordmark")
# equal to...
brand.logo.images["wordmark"].to_html()
```

When an image includes light/dark variants, we include both images with an additional `data-when-theme="light"` attribute (or `data-when-theme="dark"`) along with inline CSS to hide the light or dark variant when in the opposite color scheme. By default, we use selectors optimized for Quarto and Shiny, but these are customizable via the `selectors` option

```python
# Use system settings only to control display
brand.logo.medium.to_html(selectors="prefers-color-scheme")

# Use Quarto or Shiny (Bootstrap) selectors
brand.logo.medium.to_html()

# Use custom selectors
brand.logo.medium.to_html(selectors={"light": ".light-mode", "dark": ".dark-mode"})
```