### PR TITLE
fix: kebab → snake casing with conflicts

### DIFF
--- a/pkg-r/R/read_brand_yml.R
+++ b/pkg-r/R/read_brand_yml.R
@@ -98,8 +98,7 @@ as_brand_yml.character <- function(brand) {
 
 #' @export
 as_brand_yml.list <- function(brand) {
-  # brand <- list_restyle_names(brand, "kebab")
-
+  # Validate and normalize the brand structure
   brand <- brand_meta_normalize(brand)
   brand <- brand_color_normalize(brand)
   brand <- brand_typography_normalize(brand)

--- a/pkg-r/R/read_brand_yml.R
+++ b/pkg-r/R/read_brand_yml.R
@@ -98,7 +98,7 @@ as_brand_yml.character <- function(brand) {
 
 #' @export
 as_brand_yml.list <- function(brand) {
-  brand <- list_restyle_names(brand, "kebab")
+  # brand <- list_restyle_names(brand, "kebab")
 
   brand <- brand_meta_normalize(brand)
   brand <- brand_color_normalize(brand)

--- a/pkg-r/R/utils.R
+++ b/pkg-r/R/utils.R
@@ -105,11 +105,16 @@ list_restyle_names <- function(x, style = c("snake", "kebab")) {
 
   if (inherits(x, c("brand_yml", "list"))) {
     if (!is.null(names(x))) {
-      names(x) <- switch(
+      new_names <- switch(
         style,
         snake = as_snake_case(names(x)),
         kebab = as_kebab_case(names(x))
       )
+      is_conflicted <-
+        (new_names %in% names(x)) | # skip unchanged names
+        (names(x) %in% names(x)[duplicated(names(x))]) | # skip original duplicates
+        new_names %in% new_names[duplicated(new_names)] # skip would-be duplicates
+      names(x)[!is_conflicted] <- new_names[!is_conflicted]
     }
     x <- map(x, list_restyle_names, style)
   }

--- a/pkg-r/tests/testthat/test-brand_typography.R
+++ b/pkg-r/tests/testthat/test-brand_typography.R
@@ -124,8 +124,8 @@ test_that("brand.typography.monospace with properties is forwarded, but overridd
       base = "Times New Roman",
       headings = "Helvetica",
       monospace = monospace,
-      monospace_inline = list(weight = 600),
-      monospace_block = list(size = "1.5em")
+      "monospace-inline" = list(weight = 600),
+      "monospace-block" = list(size = "1.5em")
     )
   ))
 

--- a/pkg-r/tests/testthat/test-utils.R
+++ b/pkg-r/tests/testthat/test-utils.R
@@ -46,17 +46,24 @@ describe("maybe_convert_font_size_to_rem()", {
 
 describe("list_restyle_names()", {
   it("converts names to snake case", {
-    input_list <- list(a_b = 1, c_d = 2)
+    input_list <- list("a-b" = 1, "c-d" = 2)
     expected_output <- list(a_b = 1, c_d = 2)
     output <- list_restyle_names(input_list, style = "snake")
     expect_equal(output, expected_output)
   })
 
   it("converts names to kebab case", {
-    input_list <- list("a-b" = 1, "c-d" = 2)
+    input_list <- list(a_b = 1, c_d = 2)
     expected_output <- list("a-b" = 1, "c-d" = 2)
     output <- list_restyle_names(input_list, style = "kebab")
     expect_equal(output, expected_output)
+  })
+
+  it("does not change names without '-' or '_'", {
+    x <- list(aa = 1, ab = 2)
+    names(x) <- c("aa", "ab")
+    expect_identical(names(list_restyle_names(x, "snake")), c("aa", "ab"))
+    expect_identical(names(list_restyle_names(x, "kebab")), c("aa", "ab"))
   })
 
   it("handles nested lists", {
@@ -78,5 +85,53 @@ describe("list_restyle_names()", {
     expected_output <- list(1, 2, 3)
     output <- list_restyle_names(input_list, style = "snake")
     expect_equal(output, expected_output)
+  })
+
+  it("avoids converting names that would create duplicates", {
+    input_list <- list("a_b" = "a_b", "a-b" = "a-b")
+    expect_equal(list_restyle_names(input_list[2:1], "snake"), input_list[2:1])
+    expect_equal(list_restyle_names(input_list, "kebab"), input_list)
+  })
+
+  it("snake: skips if it would duplicate an existing original name", {
+    x <- list(a_b = 1, "a-b" = 2)
+    expect_identical(list_restyle_names(x, "snake"), x)
+    expect_identical(list_restyle_names(x[2:1], "snake"), x[2:1])
+  })
+
+  it("kebab: skips if it would duplicate an existing original name", {
+    x <- list("a-b" = 1, a_b = 2)
+    expect_identical(list_restyle_names(x, "kebab"), x)
+    expect_identical(list_restyle_names(x[2:1], "kebab"), x[2:1])
+  })
+
+  it("snake: only entirely non-duplicated names can be converted", {
+    x <- list("p-q" = 1, "p-q" = 2, "r-s" = 3)
+    expected <- set_names(x, c("p-q", "p-q", "r_s"))
+    expect_equal(list_restyle_names(x, "snake"), expected)
+  })
+
+  it("kebab: only entirely non-duplicated names can be converted", {
+    x <- list("p_q" = 1, "p_q" = 2, "r_s" = 3)
+    expected <- set_names(x, c("p_q", "p_q", "r-s"))
+    expect_equal(list_restyle_names(x, "kebab"), expected)
+  })
+
+  it("round trips snake -> kebab -> snake", {
+    # note we start with entirely snake-case names
+    x <- list("p_q" = 1, "p_q" = 2, "r_s" = 3)
+    expect_equal(
+      list_restyle_names(list_restyle_names(x, "kebab"), "snake"),
+      x
+    )
+  })
+
+  it("round trips kebab -> snake -> kebab", {
+    # note we start with entirely kebab-case names
+    x <- list("p-q" = 1, "p-q" = 2, "r-s" = 3)
+    expect_equal(
+      list_restyle_names(list_restyle_names(x, "snake"), "kebab"),
+      x
+    )
   })
 })


### PR DESCRIPTION
When kebab → snake case conversion (or vice versa) would introduce new name conflicts, we skip changing the case.

``` r
pkgload::load_all()
#> ℹ Loading brand.yml

list(a_b = 1, "a-b" = 2) |> list_restyle_names("snake") |> names()
#> [1] "a_b" "a-b"
list("a-b" = 1, a_b = 2) |> list_restyle_names("kebab") |> names()
#> [1] "a-b" "a_b"
list("p-q" = 1, "p-q" = 2, "r-s" = 3) |> list_restyle_names("snake") |> names()
#> [1] "p-q" "p-q" "r_s"
list("p_q" = 1, "p_q" = 2, "r_s" = 3) |> list_restyle_names("kebab") |> names()
#> [1] "p_q" "p_q" "r-s"
```