### PR TITLE
fix(pkgdown): set proper root URL for source/home

### DIFF
--- a/pkg-r/pkgdown/_pkgdown.yml
+++ b/pkg-r/pkgdown/_pkgdown.yml
@@ -1,5 +1,10 @@
 url: https://posit-dev.github.io/brand-yml/pkg/r
 
+repo:
+  url:
+    home: https://github.com/posit-dev/brand-yml/tree/main/pkg-r
+    source: https://github.com/posit-dev/brand-yml/blob/HEAD/pkg-r
+
 destination: "../docs/pkg/r"
 
 development:


### PR DESCRIPTION
The source links are broken as they target the root of the repositories instead of the root of the R package.