### PR TITLE
fix: annotate Logo.tagify() return type as htmltools.Tagified

### DIFF
--- a/pkg-py/src/brand_yml/logo.py
+++ b/pkg-py/src/brand_yml/logo.py
@@ -140,7 +140,7 @@ class BrandLogoResource(BrandBase):
         else:
             raise ValueError("format_type must be 'html' or 'markdown'")
 
-    def tagify(self) -> htmltools.Tag:
+    def tagify(self) -> htmltools.Tagified:
         """
         Convenience method for `.to_html()`, for use in Shiny apps.
 
@@ -149,7 +149,7 @@ class BrandLogoResource(BrandBase):
         :
             HTML img tag as a string.
         """
-        return self.to_html()
+        return self.to_html().tagify()
 
     def _repr_html_(self) -> str:
         """Jupyter notebook HTML representation."""
@@ -328,7 +328,7 @@ class BrandLogoResourceLightDark(BrandLightDark[BrandLogoResource]):
         else:
             raise ValueError("format_type must be 'html' or 'markdown'")
 
-    def tagify(self) -> htmltools.Tag:
+    def tagify(self) -> htmltools.Tagified:
         """
         Convenience method for `.to_html()`, for use in Shiny apps.
 
@@ -337,7 +337,7 @@ class BrandLogoResourceLightDark(BrandLightDark[BrandLogoResource]):
         :
             HTML span with light and dark images.
         """
-        return self.to_html()
+        return self.to_html().tagify()
 
     def _repr_html_(self) -> str:
         """Jupyter notebook HTML representation."""

--- a/pkg-py/src/brand_yml/logo.py
+++ b/pkg-py/src/brand_yml/logo.py
@@ -11,7 +11,7 @@ import base64
 import mimetypes
 import warnings
 from pathlib import Path
-from typing import Annotated, Any, Literal, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union
 
 import htmltools
 from pydantic import (
@@ -28,6 +28,13 @@ from ._html_deps import html_dep_brand_light_dark
 from ._utils_docs import add_example_yaml
 from .base import BrandBase
 from .file import FileLocation, FileLocationLocal, FileLocationLocalOrUrlType
+
+if TYPE_CHECKING:
+    # `Tagified` is only available in htmltools >= 0.7.0
+    # (posit-dev/py-htmltools#105). Reference it via a TYPE_CHECKING
+    # import so this module still loads against the released htmltools
+    # — `from __future__ import annotations` defers the annotation.
+    from htmltools import Tagified
 
 
 class BrandLogoResource(BrandBase):
@@ -140,7 +147,7 @@ class BrandLogoResource(BrandBase):
         else:
             raise ValueError("format_type must be 'html' or 'markdown'")
 
-    def tagify(self) -> htmltools.Tagified:
+    def tagify(self) -> Tagified:
         """
         Convenience method for `.to_html()`, for use in Shiny apps.
 
@@ -328,7 +335,7 @@ class BrandLogoResourceLightDark(BrandLightDark[BrandLogoResource]):
         else:
             raise ValueError("format_type must be 'html' or 'markdown'")
 
-    def tagify(self) -> htmltools.Tagified:
+    def tagify(self) -> Tagified:
         """
         Convenience method for `.to_html()`, for use in Shiny apps.
 

--- a/pkg-py/src/brand_yml/logo.py
+++ b/pkg-py/src/brand_yml/logo.py
@@ -30,11 +30,16 @@ from .base import BrandBase
 from .file import FileLocation, FileLocationLocal, FileLocationLocalOrUrlType
 
 if TYPE_CHECKING:
+    import sys
+
     # `Tagified` is only available in htmltools >= 0.7.0
-    # (posit-dev/py-htmltools#105). Reference it via a TYPE_CHECKING
-    # import so this module still loads against the released htmltools
-    # — `from __future__ import annotations` defers the annotation.
-    from htmltools import Tagified
+    # (posit-dev/py-htmltools#105), which requires Python >= 3.10.
+    # On 3.9 we pin to an older htmltools that doesn't export
+    # `Tagified`, so fall back to `object` for type-checking.
+    if sys.version_info >= (3, 10):
+        from htmltools import Tagified
+    else:
+        Tagified = object
 
 
 class BrandLogoResource(BrandBase):

--- a/pkg-py/tests/test_logo_formatting.py
+++ b/pkg-py/tests/test_logo_formatting.py
@@ -6,10 +6,10 @@ import htmltools
 import pytest
 from brand_yml import Brand
 from brand_yml._defs import BrandLightDark
+from brand_yml._html_deps import html_dep_brand_light_dark
 from brand_yml.logo import (
     BrandLogoResource,
     BrandLogoResourceLightDark,
-    html_dep_brand_light_dark,
 )
 
 

--- a/pkg-py/tests/test_logo_formatting.py
+++ b/pkg-py/tests/test_logo_formatting.py
@@ -101,8 +101,10 @@ class TestBrandLogoResourceFormatting:
         html1 = simple_logo.tagify()
         html2 = simple_logo.to_html()
 
-        # Should be identical
-        assert html1 == html2
+        # `tagify()` returns a `TagifiedTag` (immutable sibling of `Tag`
+        # from htmltools >= 0.7.0), so `==` is never true across the two
+        # sibling types. Compare rendered HTML instead.
+        assert str(html1) == str(html2)
 
     def test_str_method(self, simple_logo):
         """Test __str__ method defaults to markdown"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ dev = [
 [tool.uv]
 upgrade-package = ["brand_yml"]
 
+# TODO(htmltools-105): remove this source override before merging.
+# Pins htmltools to the PR branch that adds the `Tagified` alias
+# (posit-dev/py-htmltools#106). Flip back to the released htmltools
+# once it ships.
+[tool.uv.sources]
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue" }
+
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,15 +60,6 @@ dev = [
 [tool.uv]
 upgrade-package = ["brand_yml"]
 
-# TODO(htmltools-116): remove this source override before merging.
-# Pins htmltools to PR #120 (the sibling-classes refactor for
-# tagified content). Flip back to the released htmltools once 0.7.0
-# ships.
-[tool.uv.sources]
-htmltools = [
-    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main", marker = "python_version >= '3.10'" },
-]
-
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "ruamel-yaml>=0.18.0",
     "pydantic>=2.10.0",
     "eval-type-backport>=0.2.0",
-    "htmltools>=0.2.0"
+    "htmltools>=0.7.0"
 ]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ upgrade-package = ["brand_yml"]
 # ships.
 [tool.uv.sources]
 htmltools = [
-    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/issue-116-sibling-classes", marker = "python_version >= '3.10'" },
+    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main", marker = "python_version >= '3.10'" },
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ upgrade-package = ["brand_yml"]
 # once it ships.
 [tool.uv.sources]
 htmltools = [
-    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue", marker = "python_version >= '3.10'" },
+    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main", marker = "python_version >= '3.10'" },
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ dependencies = [
     "ruamel-yaml>=0.18.0",
     "pydantic>=2.10.0",
     "eval-type-backport>=0.2.0",
-    "htmltools>=0.7.0"
+    "htmltools>=0.7.0;python_version>='3.10'",
+    "htmltools<0.7.0;python_version<'3.10'"
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -64,7 +65,9 @@ upgrade-package = ["brand_yml"]
 # (posit-dev/py-htmltools#106). Flip back to the released htmltools
 # once it ships.
 [tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue" }
+htmltools = [
+    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue", marker = "python_version >= '3.10'" },
+]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,13 @@ dev = [
 [tool.uv]
 upgrade-package = ["brand_yml"]
 
-# TODO(htmltools-105): remove this source override before merging.
-# Pins htmltools to the PR branch that adds the `Tagified` alias
-# (posit-dev/py-htmltools#106). Flip back to the released htmltools
-# once it ships.
+# TODO(htmltools-116): remove this source override before merging.
+# Pins htmltools to PR #120 (the sibling-classes refactor for
+# tagified content). Flip back to the released htmltools once 0.7.0
+# ships.
 [tool.uv.sources]
 htmltools = [
-    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main", marker = "python_version >= '3.10'" },
+    { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/issue-116-sibling-classes", marker = "python_version >= '3.10'" },
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

The upcoming htmltools 0.7.0 release ([posit-dev/py-htmltools#120](https://github.com/posit-dev/py-htmltools/pull/120), closes posit-dev/py-htmltools#116) refactors tagified content into immutable sibling classes and tightens the `Tagifiable.tagify()` Protocol return type from a bare `Tag | TagList | MetadataNode | str | HTML` to the new `Tagified` union — the only tagified-shape alias exported by htmltools.

The two `Logo.tagify()` methods in `pkg-py/src/brand_yml/logo.py` were declared `-> htmltools.Tag`. That's no longer a subtype of the Protocol return: under htmltools 0.7.0, `Tag.tagify()` returns a `TagifiedTag` (an immutable sibling of `Tag`, not a subclass), and the canonical annotation is the broad `Tagified` union.

Change the annotations to `htmltools.Tagified` and call `.tagify()` on the `to_html()` result so the value matches the recursive tagified invariant.

Python 3.9 compatibility: htmltools 0.7.0 drops Python 3.9, so this PR conditionally pins `htmltools<0.7.0` on 3.9 and `htmltools>=0.7.0` on 3.10+. The `Tagified` import in `logo.py` falls back to `object` on 3.9 (where the alias is unavailable).

## Dependency

Depends on [posit-dev/py-htmltools#120](https://github.com/posit-dev/py-htmltools/pull/120). The `[tool.uv.sources]` git pin currently points at the PR branch; revert to released `htmltools>=0.7.0` once it ships on PyPI.

## Test plan

- [x] Pyright against the new htmltools → 0 errors
- [x] Runtime behavior unchanged: the `to_html()` result contains only leaf children, so `.tagify()` is idempotent