### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
-## [UNRELEASED]
+## [0.2.0] - 2026-05-21
+
+### New features
 
 * `Brand.from_yaml()` now consults the `BRAND_YML_PATH` environment variable when `path` is not provided. (#90)
 
@@ -15,9 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `Brand.use_logo()` method to resolve and use brand logos in a variety of contexts, including Shiny apps. (#98)
 
-* Use PEP 735 `dependency-groups` for dev dependencies. (#100)
+### Bug fixes
+
+* `BrandLogoResource.tagify()` and `BrandLogoResourceLightDark.tagify()` now annotate their return type as `htmltools.Tagified` and fully tagify their output, complying with htmltools 0.7.0's tightened Tagifiable contract. Without this fix, rendering a brand logo with htmltools 0.7.0+ raises `TypeError` at the render boundary. (#115)
+
+### Breaking changes
+
+* Dropped support for Python 3.9, which reached end of life on
+  2025-10-31. brand_yml now requires Python 3.10 or later.
+
+### Dependencies
 
 * brand_yml now requires pydantic 2.10+. (#100)
+
+### Other changes
+
+* Use PEP 735 `dependency-groups` for dev dependencies. (#100)
 
 ## [0.1.1]
 

--- a/pkg-py/src/brand_yml/logo.py
+++ b/pkg-py/src/brand_yml/logo.py
@@ -30,16 +30,7 @@ from .base import BrandBase
 from .file import FileLocation, FileLocationLocal, FileLocationLocalOrUrlType
 
 if TYPE_CHECKING:
-    import sys
-
-    # `Tagified` is only available in htmltools >= 0.7.0
-    # (posit-dev/py-htmltools#105), which requires Python >= 3.10.
-    # On 3.9 we pin to an older htmltools that doesn't export
-    # `Tagified`, so fall back to `object` for type-checking.
-    if sys.version_info >= (3, 10):
-        from htmltools import Tagified
-    else:
-        Tagified = object
+    from htmltools import Tagified
 
 
 class BrandLogoResource(BrandBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,19 +2,17 @@
 name = "brand_yml"
 description = "Read brand yaml files, a unified way to store brand information."
 readme = "pkg-py/README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "ruamel-yaml>=0.18.0",
     "pydantic>=2.10.0",
     "eval-type-backport>=0.2.0",
-    "htmltools>=0.7.0;python_version>='3.10'",
-    "htmltools<0.7.0;python_version<'3.10'"
+    "htmltools>=0.7.0",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -112,7 +110,7 @@ exclude_lines = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-env_list = type-py3{9,10,11,12,13,14}, py3{9,10,11,12,13,14}
+env_list = type-py3{10,11,12,13,14}, py3{10,11,12,13,14}
 isolated_build = True
 
 [testenv]
@@ -164,7 +162,7 @@ exclude = [
 line-length = 80
 indent-width = 4
 
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ['E', 'F', 'W', 'A', 'PLC', 'PLE', 'PLW', 'I']


### PR DESCRIPTION
## Summary

Cuts brand-yml **0.2.0**. Per @gadenbuie's review: drops Python 3.9 (EOL 2025-10-31) instead of carrying conditional 3.9-only code alongside the htmltools 0.7.0 compat work.

### What's in 0.2.0

**Breaking changes**
- Dropped support for Python 3.9. brand_yml now requires Python 3.10+.

**New features**
- `Brand.from_yaml()` honors `BRAND_YML_PATH` env var. (#90)
- `use_brand_yml_path()` context manager. (#92)
- `Brand.use_logo()` for resolving brand logos in Shiny apps. (#98)

**Bug fixes**
- `BrandLogoResource.tagify()` / `BrandLogoResourceLightDark.tagify()` now return `htmltools.Tagified` and fully tagify their output, complying with htmltools 0.7.0's tightened Tagifiable contract. Without this, rendering a brand logo on htmltools 0.7.0+ raises `TypeError` at the render boundary. (#115)

**Dependencies**
- Requires pydantic 2.10+. (#100)

**Other**
- PEP 735 `dependency-groups` for dev deps. (#100)

## Changes from the original release-prep commit

Per @gadenbuie's suggestion, dropping 3.9 lets us simplify several spots that were carrying conditional code only for 3.9:

- `pyproject.toml` — `requires-python = ">=3.10"`, dropped the `htmltools<0.7.0;python_version<'3.10'` split, dropped the 3.9 classifier, ruff `target-version = "py310"`, tox `env_list` drops 3.9.
- `.github/workflows/py-test.yml` — dropped 3.9 from the CI matrix.
- `pkg-py/src/brand_yml/logo.py` — replaced the `sys.version_info`-gated `Tagified` fallback with a plain unconditional `from htmltools import Tagified` (still under `TYPE_CHECKING`).

Verified locally on Python 3.10: pyright clean, 122/122 tests pass.

## After merge

Per `.github/workflows/py-release.yml` (fires on `release: published` with tag `py/v*`):

1. Tag the merge commit `py/v0.2.0`.
2. Publish a GitHub Release on that tag.
3. `py-release.yml` runs the Python checks, builds, and trusted-publishes to PyPI.

Version is computed by `hatch-vcs` from the tag.