### PR TITLE
ci(py-release): use --group test instead of --extra test

### DIFF
--- a/.github/workflows/py-release.yml
+++ b/.github/workflows/py-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: uv python install ${{ env.PYTHON_VERSION }}
 
       - name: 📦 Install the project
-        run: uv sync --python ${{ env.PYTHON_VERSION }} --no-dev --extra test
+        run: uv sync --python ${{ env.PYTHON_VERSION }} --no-dev --group test
 
       - name: 🧪 Check tests
         run: make py-check-tests


### PR DESCRIPTION
## Summary

The py/v0.2.0 release workflow failed at the `Install the project` step:

> error: Extra \`test\` is not defined in the project's \`optional-dependencies\` table

#100 moved `test` from `[project.optional-dependencies]` to a PEP 735 `[dependency-groups]` table. `py-test.yml` was updated at the same time to use `--group test`, but `py-release.yml` was missed — it still passes `--extra test`, which uv now rejects.

This is why brand_yml 0.2.0 never made it to PyPI even though the GitHub Release was published.

## After merge

1. Delete the existing `py/v0.2.0` release + tag (it was never published to PyPI).
2. Re-tag `py/v0.2.0` on the new HEAD of `main`.
3. Re-publish the GitHub Release; `py-release.yml` should now run cleanly.

`hatch-vcs` computes the version from the tag, so 0.2.0 is preserved regardless of which commit it's placed on.

## Test plan

- [ ] After merge: re-tag + re-publish release, confirm `py-release.yml` succeeds and `pip install brand_yml==0.2.0` works from PyPI.